### PR TITLE
Remove systematic escaping of < and >

### DIFF
--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -167,8 +167,6 @@ var sanitizeUserInput = function (input) {
     element.innerText = input;
 
     return element.innerHTML
-      .replace(/</gu, '&lt;')
-      .replace(/>/gu, '&gt;')
       .replace(/"/gu, '&quot;')
       .replace(/'/gu, '&#x27;');
 }


### PR DESCRIPTION
This fixes an issue where "safe" HTML element nodes such as `<br>` would be escaped and rendered as text.